### PR TITLE
Config improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ the content of `derive.semi.conf`. (Some merge strategy for resources I guess?
 That and making sure that compiler _sees_ the resources, since if you define them
 in the same project you want compiler to use them it is not the case).
 
+Take a look at [example](modules/catnip-custom-example) project to see how it works
+in practice.
+
 ## Limitations
 
 Type checker complains if you use type aliases from the same compilation unit

--- a/README.md
+++ b/README.md
@@ -105,12 +105,25 @@ In order to do so it:
    (`shapeless.Typeable[A]`), they are defined in config after the generator
    function and separated by commas
 
-Therefore, you should be able to extend the abilities of the macro by expanding
-the content of `derive.semi.conf`. (Some merge strategy for resources I guess?
-That and making sure that compiler _sees_ the resources, since if you define them
-in the same project you want compiler to use them it is not the case).
+## Customizations
 
-Take a look at [example](modules/catnip-custom-example) project to see how it works
+You should be able to extend the abilities of the macro by expanding
+the content of `derive.semi.conf`. You can create this file and add it to your library
+if you want Catnip to support it as all files with that name are looked through during
+compilation. When it comes to sbt it doesn't export resources to `Compile` scope,
+so your configs might not be visible in your modules while they would be available
+in created JARs. (Creating somewhat inconsistent experience).
+Personally, I fixed this by adding something like
+
+```
+val myProject = project.in(file("my-project"))
+  // other settings
+  .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "../src/main/resources")
+```
+
+to sbt. This will make your customizations immediately available to your modules.
+
+Take a look at an [example](modules/catnip-custom-example) project to see how it works
 in practice.
 
 ## Limitations

--- a/catnip.sbt
+++ b/catnip.sbt
@@ -47,6 +47,7 @@ lazy val readme = scalatex.ScalatexReadme(
   .noPublish
   .enablePlugins(GhpagesPlugin)
   .settings(
+    scalaVersion := "2.12.11", // there is no ScalaTex for 2.13
     siteSourceDirectory := target.value / "scalatex",
     git.remoteRepo := "git@github.com:scalalandio/catnip.git",
     Jekyll / makeSite / includeFilter := new FileFilter { def accept(p: File) = true }
@@ -54,4 +55,3 @@ lazy val readme = scalatex.ScalatexReadme(
 
 addCommandAlias("fullTest", ";test;scalastyle")
 addCommandAlias("fullCoverageTest", ";coverage;test;coverageReport;coverageAggregate;scalastyle")
-addCommandAlias("relock", ";unlock;reload;update;lock")

--- a/catnip.sbt
+++ b/catnip.sbt
@@ -7,7 +7,7 @@ lazy val root = project.root
   .setDescription("Catnip build")
   .configureRoot
   .noPublish
-  .aggregate(catnipJVM, catnipJS, catnipTestsJVM, catnipTestsJS)
+  .aggregate(catnipJVM, catnipJS, catnipCustomTestsJVM, catnipCustomTestsJS, catnipTestsJVM, catnipTestsJS)
 
 lazy val catnip = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).build.from("catnip")
   .setName("catnip")
@@ -21,11 +21,24 @@ lazy val catnipJVM = catnip.jvm
 lazy val catnipJS  = catnip.js
   .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "../src/main/resources")
 
+lazy val catnipCustomTests = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).build.from("catnip-custom-example")
+  .setName("catnip-custom-example")
+  .setDescription("Example for custom derivation")
+  .setInitialImport("cats.implicits._, alleycats.std.all._")
+  .dependsOn(catnip)
+  .configureModule
+  .noPublish
+
+lazy val catnipCustomTestsJVM = catnipCustomTests.jvm
+  .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "../src/main/resources")
+lazy val catnipCustomTestsJS  = catnipCustomTests.js
+  .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "../src/main/resources")
+
 lazy val catnipTests = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).build.from("catnip-tests")
   .setName("catnip-tests")
   .setDescription("Catnip tests")
   .setInitialImport("cats.implicits._, alleycats.std.all._")
-  .dependsOn(catnip)
+  .dependsOn(catnip, catnipCustomTests)
   .configureModule
   .configureTests()
   .noPublish

--- a/modules/catnip-custom-example/src/main/resources/derive.semi.conf
+++ b/modules/catnip-custom-example/src/main/resources/derive.semi.conf
@@ -1,0 +1,1 @@
+io.scalaland.catnip.CustomDerivation=io.scalaland.catnip.NotACompanion.derive

--- a/modules/catnip-custom-example/src/main/resources/derive.stub.conf
+++ b/modules/catnip-custom-example/src/main/resources/derive.stub.conf
@@ -1,0 +1,1 @@
+io.scalaland.catnip.FakeCompanion=io.scalaland.catnip.CustomDerivation

--- a/modules/catnip-custom-example/src/main/scala/io/scalaland/catnip/CustomDerivation.scala
+++ b/modules/catnip-custom-example/src/main/scala/io/scalaland/catnip/CustomDerivation.scala
@@ -1,0 +1,47 @@
+package io.scalaland.catnip
+
+import shapeless._
+
+// define a type class (or have a library define it for you)
+trait CustomDerivation[A] {
+
+  def doSomething(a: A): A
+}
+
+object NotACompanion {
+
+  trait Derived[A] extends CustomDerivation[A]
+
+  private def instance[A](f: A => A): Derived[A] = new Derived[A] {
+    override def doSomething(a: A) = f(a)
+  }
+
+  // let's pretend this is semi-auto macro or sth
+  //
+  // add full.name.to.derive.method into derive.semi.conf e.g.:
+  //   io.scalaland.catnip.CustomDerivation=io.scalaland.catnip.NotACompanion.derive
+  def derive[A](implicit tc: Derived[A]): CustomDerivation[A] = tc
+
+  implicit def hlist[A, ARepr <: HList](implicit gen: Generic.Aux[A, ARepr], reprTC: Derived[ARepr]): Derived[A] =
+    instance { a =>
+      gen.from(reprTC.doSomething(gen.to(a)))
+    }
+
+  implicit val hNil: Derived[HNil] = instance { _ =>
+    HNil
+  }
+
+  implicit def hCons[H, T <: HList](implicit hTC: Derived[H], tTC: Derived[T]): Derived[H :: T] = instance {
+    case h :: t =>
+      hTC.doSomething(h) :: tTC.doSomething(t)
+  }
+
+  implicit val string: Derived[String] = instance(s => s)
+
+  implicit val int: Derived[Int] = instance(s => s)
+}
+
+// if a type class is missing a companion which we could pass as @Semi(TypeClass)
+// we could create a fake companion which we could use instead and configure it in derive.stub.conf e.g.
+//   io.scalaland.catnip.FakeCompanion=io.scalaland.catnip.CustomDerivation
+object FakeCompanion

--- a/modules/catnip-tests/src/test/scala/io/scalaland/catnip/CustomSpec.scala
+++ b/modules/catnip-tests/src/test/scala/io/scalaland/catnip/CustomSpec.scala
@@ -1,0 +1,22 @@
+package io.scalaland.catnip
+
+import org.specs2.mutable.Specification
+
+@Semi(FakeCompanion) final case class CustomType(a: String, b: Int)
+
+class CustomSpec extends Specification {
+
+  "customized @Semi" should {
+
+    "handle custom configs" in {
+      // given
+      val value = CustomType("test", 5354)
+
+      // when
+      val result = implicitly[CustomDerivation[CustomType]].doSomething(value)
+
+      // then
+      result must_=== value
+    }
+  }
+}

--- a/modules/catnip/src/main/scala/io/scalaland/catnip/internals/Loggers.scala
+++ b/modules/catnip/src/main/scala/io/scalaland/catnip/internals/Loggers.scala
@@ -1,6 +1,5 @@
 package io.scalaland.catnip.internals
 
-@SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
 private[internals] trait Loggers {
 
   sealed abstract class Level(val name: String, val ordinal: Int) extends Product with Serializable {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -7,7 +7,6 @@ import com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin.autoImport._
 import org.scalastyle.sbt.ScalastylePlugin.autoImport._
 import sbtcrossproject.CrossProject
 import scoverage._
-import wartremover._
 
 object Settings extends Dependencies {
 
@@ -131,21 +130,7 @@ object Settings extends Dependencies {
 
     Compile / scalafmtOnCompile := true,
 
-    scalastyleFailOnError := true,
-
-    Compile / compile / wartremoverWarnings ++= Warts.allBut(
-      Wart.Any,
-      Wart.AsInstanceOf,
-      Wart.DefaultArguments,
-      Wart.ExplicitImplicitTypes,
-      Wart.ImplicitConversion,
-      Wart.ImplicitParameter,
-      Wart.Overloading,
-      Wart.PublicInference,
-      Wart.NonUnitStatements,
-      Wart.Nothing,
-      Wart.ToString
-    )
+    scalastyleFailOnError := true
   ) ++ mainDeps ++ Seq(
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,6 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.2")
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.11")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")


### PR DESCRIPTION
* read more than one `derive.semi.conf` (previous implementation required to copy all settings from default one)
* add `derive.stub.conf` to allow using `@Semi(TypeClass)` with type classes that don't have companion (using stub `object` name instead)